### PR TITLE
fix: allow localterra path browsing cancellation

### DIFF
--- a/public/settings.js
+++ b/public/settings.js
@@ -29,7 +29,7 @@ module.exports = (win, globals) => {
       // eslint-disable-next-line no-param-reassign
       globals.localTerraProcess = startLocalTerra(filePaths[0]);
       await subscribeToLocalTerraEvents(globals.localTerraProcess, win);
-    } else if (!isValid) {
+    } else if (!isValid && typeof globals.localTerraPath !== 'undefined') {
       await showWrongDirectoryDialog();
       throw Error(`LocalTerra does not exist under the path '${globals.localTerraPath}'`);
     }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -134,7 +134,9 @@ export default function Settings() {
                     endAdornment: (
                       <Button onClick={async () => {
                         const newPath = await ipcRenderer.invoke('setLocalTerraPath', false);
-                        resetField('localTerraPath', { defaultValue: newPath });
+                        if (newPath) {
+                          resetField('localTerraPath', { defaultValue: newPath });
+                        }
                       }}
                       >
                         Browse


### PR DESCRIPTION
Currently, if a user tries to browse for a new localterra directory in settings and clicks cancel, they are met with an error due to not selecting an appropriate localterra directory.  This implementation allows the user to cancel without an error prompt and retain their prior localterra path.