### PR TITLE
[DTE-6] Keep block details expanded even when the block view is off screen.

### DIFF
--- a/src/components/BlockView.tsx
+++ b/src/components/BlockView.tsx
@@ -17,9 +17,6 @@ const BlockView = (props: {
   const { result_begin_block, hasEventsOpenInUi } = props.data;
   const { gridTemplateColumns } = props;
   const blockHref = `${REACT_APP_FINDER_URL}/blocks/${height}`;
-
-  const [open, setOpen] = React.useState(hasEventsOpenInUi);
-
   const txInfos = useGetTxFromHeight(parseInt(height, 10));
   const dateString = `${new Date(time).toDateString()} | ${new Date(
     time,
@@ -31,7 +28,6 @@ const BlockView = (props: {
   });
 
   const toggleBlocksRow = () => {
-    setOpen(!open);
     props.onToggleEventDetails(props.index);
   };
 
@@ -61,12 +57,12 @@ const BlockView = (props: {
         <div>{gasUsed}</div>
         <div className="flex justify-end">
           <KeyboardArrowDownIcon
-            className={`cursor-pointer ${open ? 'rotate-180' : 'rotate-0'}`}
+            className={`cursor-pointer ${hasEventsOpenInUi ? 'rotate-180' : 'rotate-0'}`}
           />
         </div>
       </div>
       <div className="bg-white">
-        <Collapse in={open} timeout="auto" unmountOnExit className="px-20 py-7">
+        <Collapse in={hasEventsOpenInUi} timeout="auto" unmountOnExit className="px-20 py-7">
           <EventInfo
             title="Begin block event"
             events={result_begin_block.events}

--- a/src/context/ElectronContextProvider.tsx
+++ b/src/context/ElectronContextProvider.tsx
@@ -27,7 +27,7 @@ export const StateListeners = () => {
   useEffect(() => {
     ipcRenderer.on(NEW_BLOCK, (_: any, block: TerrariumBlockInfo) => {
       blockState.latestHeight.set(Number(block.block.header.height));
-      blockState.blocks.set((p) => [block, ...p]);
+      blockState.blocks.set((p) => [...p, block]);
     });
 
     ipcRenderer.on(TX, (_: any, tx: TerrariumTx) => {

--- a/src/pages/Block.tsx
+++ b/src/pages/Block.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 import { Checkbox, FormControlLabel } from '@mui/material';
 import { useBlocks } from '../hooks/terra';
@@ -6,18 +6,19 @@ import { BlockView } from '../components';
 
 export default function BlocksPage() {
   const [filter, setFilter] = React.useState(false);
-  const { get: getBlocks, set: setBlocks } = useBlocks();
-  const data = getBlocks();
+  const state = useBlocks();
+  const data = state.get();
   const gridTemplateColumns = '120px minmax(125px, 1fr) minmax(25px, 0.5fr) minmax(25px, 0.5fr) 75px';
 
   const handleToggleFilter = () => setFilter(!filter);
 
   const getFilteredBlocks = () => data.blocks.filter(({ block } : {block: any}) => block.data.txs!.length > 0);
 
-  const toggleEventDetails = (index: number) => {
-    data.blocks[index].hasEventsOpenInUi = !data.blocks[index].hasEventsOpenInUi;
-    setBlocks(data);
-  };
+  const toggleEventDetails = useCallback((index: number) => {
+    state.blocks[index].merge({
+      hasEventsOpenInUi: !data.blocks[index].hasEventsOpenInUi,
+    });
+  }, [state]);
 
   return (
     <div className="flex flex-col w-full">

--- a/src/pages/Block.tsx
+++ b/src/pages/Block.tsx
@@ -45,6 +45,7 @@ export default function BlocksPage() {
         <div />
       </div>
       <Virtuoso
+        followOutput
         className="flex flex-col w-full scrollbar"
         style={{ overflow: 'overlay' }}
         data={filter ? getFilteredBlocks() : data.blocks}


### PR DESCRIPTION
This issue has been bothering me for a while now. When looking at the events in a block, if you scroll away and come back, the details would revert back to being closed. 

This was due to the Virtuoso component unmounting the blockview when it was off screen, which caused any local state to get wiped. 

I've moved the state for the expanded block view to the component above, and rely on that for the state of the Collapse component. 

Additionally adding new blocks to the top of the list was causing other issues, like blocks jumping around ever 5 seconds, so I've decided to add new blocks to the end. 


https://user-images.githubusercontent.com/142006/213393268-a5ed5dc5-5b27-4bd4-a1d6-dcde441fd694.mov

