### PR TITLE
fix: Use an ID for the settings menu item.

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const {
-  app, shell, BrowserWindow, Menu, Tray, MenuItem, session,
+  app, shell, BrowserWindow, Menu, Tray, MenuItem,
 } = require('electron');
 const isDev = require('electron-is-dev');
 const defaultMenu = require('electron-default-menu');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -151,6 +151,7 @@ const App = () => {
                 return (
                   <div className="absolute bottom-0 left-0 w-full p-5">
                     <button
+                      id={`menuitem-${menuItem.name}`}
                       key={menuItem.name}
                       type="button"
                       onClick={() => handleToggleOpen(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -105,7 +105,7 @@ export const tourProviderProps = {
       content: 'View incoming logs from LocalTerra.',
     },
     {
-      selector: '.Settings',
+      selector: '#menuitem-Settings',
       content:
         'Manage your settings here. Like open at login, your LocalTerra path, and your desired block time.',
     },


### PR DESCRIPTION
Looks like the previous selector used for the settings menu item was removed, so I added an ID. 

<img width="1312" alt="Screen Shot 2023-01-25 at 12 49 21 PM" src="https://user-images.githubusercontent.com/142006/214655598-cad9377f-3e1d-45e2-9377-47118b6061d3.png">


Resolves DTE-10.